### PR TITLE
Document client_side_id (#35)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module terraform-provider-launchdarkly
+module github.com/terraform-providers/terraform-provider-launchdarkly
 
 require (
 	github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"terraform-provider-launchdarkly/launchdarkly"
+	"github.com/terraform-providers/terraform-provider-launchdarkly/launchdarkly"
 
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
 )

--- a/website/docs/r/environment.html.markdown
+++ b/website/docs/r/environment.html.markdown
@@ -49,6 +49,8 @@ In addition to the arguments above, the resource exports the following attribute
 
 - `mobile_key` - The environment's mobile key.
 
+- `client_side_id` - The environment's client-side ID.
+
 ## Import
 
 You can import a LaunchDarkly environment using this format: `project_key/environment_key`.


### PR DESCRIPTION
This PR documents the client_side_id attribute as requested in terraform-providers/terraform-provider-launchdarkly#1