### PR TITLE
Add mainter_id validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.2 (Unreleased)
+## 1.0.0 (Unreleased)
 
 IMPROVEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## 0.0.1 (Unreleased)
+## 0.0.2 (Unreleased)
+
+IMPROVEMENTS:
+
+- Add `maintainer_id` input validation.
+
+## 0.0.1 (October 21, 2019)
 
 NOTES:
 

--- a/launchdarkly/config.go
+++ b/launchdarkly/config.go
@@ -8,7 +8,7 @@ import (
 	ldapi "github.com/launchdarkly/api-client-go"
 )
 
-const Version = "0.0.2"
+const Version = "1.0.0"
 
 // Client is used by the provider to access the ld API.
 type Client struct {

--- a/launchdarkly/config.go
+++ b/launchdarkly/config.go
@@ -8,7 +8,7 @@ import (
 	ldapi "github.com/launchdarkly/api-client-go"
 )
 
-const Version = "0.0.1"
+const Version = "0.0.2"
 
 // Client is used by the provider to access the ld API.
 type Client struct {

--- a/launchdarkly/resource_launchdarkly_feature_flag.go
+++ b/launchdarkly/resource_launchdarkly_feature_flag.go
@@ -42,9 +42,10 @@ func resourceFeatureFlag() *schema.Resource {
 				Description: "The feature flag's description",
 			},
 			maintainer_id: {
-				Type:     schema.TypeString,
-				Computed: true,
-				Optional: true,
+				Type:         schema.TypeString,
+				Computed:     true,
+				Optional:     true,
+				ValidateFunc: validateID(),
 			},
 			description: {
 				Type:     schema.TypeString,

--- a/launchdarkly/validation_helper.go
+++ b/launchdarkly/validation_helper.go
@@ -15,6 +15,12 @@ func validateKey() schema.SchemaValidateFunc {
 	)
 }
 
+func validateID() schema.SchemaValidateFunc {
+	return validation.All(
+		validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9]{24}$`), "Must be a 24 character alphanumeric string"),
+	)
+}
+
 func validateOp() schema.SchemaValidateFunc {
 	return func(i interface{}, k string) (s []string, es []error) {
 		v, ok := i.(string)

--- a/website/docs/d/team_member.html.markdown
+++ b/website/docs/d/team_member.html.markdown
@@ -27,7 +27,7 @@ data "launchdarkly_team_member" "example" {
 
 In addition to the arguments above, the resource exports the following attributes:
 
-- `id` - The ID of the team member.
+- `id` - The 24 character alphanumeric ID of the team member.
 
 - `first_name` - The team member's given name.
 

--- a/website/docs/r/environment.html.markdown
+++ b/website/docs/r/environment.html.markdown
@@ -49,6 +49,8 @@ In addition to the arguments above, the resource exports the following attribute
 
 - `mobile_key` - The environment's mobile key.
 
+- `client_side_id` - The environment's client-side ID.
+
 ## Import
 
 You can import a LaunchDarkly environment using this format: `project_key/environment_key`.

--- a/website/docs/r/feature_flag.html.markdown
+++ b/website/docs/r/feature_flag.html.markdown
@@ -62,7 +62,7 @@ resource "launchdarkly_feature_flag" "building_materials" {
 
 - `tags` - (Optional) Set of feature flag tags.
 
-- `maintainer_id` - (Optional) The feature flag maintainer's team member ID.
+- `maintainer_id` - (Optional) The feature flag maintainer's 24 character alphanumeric team member ID.
 
 - `temporary` - (Optional) Specifies whether the flag is a temporary flag.
 

--- a/website/docs/r/team_member.html.markdown
+++ b/website/docs/r/team_member.html.markdown
@@ -42,7 +42,7 @@ resource "launchdarkly_team_member" "example" {
 
 In addition to the arguments above, the resource exports the following attribute:
 
-- `id` - The ID of the team member.
+- `id` - The 24 character alphanumeric ID of the team member.
 
 ## Import
 


### PR DESCRIPTION
This PR adds basic input validation to the the `resource_launchdarkly_feature_flag` `maintainer_id` argument. The website documentation has also been updated to further clarify this attribute.

### Acceptance tests
```
=== RUN   TestCleanAccount
--- SKIP: TestCleanAccount (0.00s)
=== RUN   TestCustomPropertiesRoundTripConversion
=== RUN   TestCustomPropertiesRoundTripConversion/basic_custom_property
=== RUN   TestCustomPropertiesRoundTripConversion/Multiple_custom_properties
--- PASS: TestCustomPropertiesRoundTripConversion (0.00s)
    --- PASS: TestCustomPropertiesRoundTripConversion/basic_custom_property (0.00s)
    --- PASS: TestCustomPropertiesRoundTripConversion/Multiple_custom_properties (0.00s)
=== RUN   TestAccDataSourceTeamMember_noMatchReturnsError
=== PAUSE TestAccDataSourceTeamMember_noMatchReturnsError
=== RUN   TestAccDataSourceTeamMember_exists
--- PASS: TestAccDataSourceTeamMember_exists (0.80s)
=== RUN   TestEnvironmentPostFromResourceData
=== RUN   TestEnvironmentPostFromResourceData/all_fields
=== RUN   TestEnvironmentPostFromResourceData/all_required_fields
--- PASS: TestEnvironmentPostFromResourceData (0.00s)
    --- PASS: TestEnvironmentPostFromResourceData/all_fields (0.00s)
    --- PASS: TestEnvironmentPostFromResourceData/all_required_fields (0.00s)
=== RUN   TestRepeatUntilNoConflict
=== RUN   TestRepeatUntilNoConflict/no_retries_needed
=== PAUSE TestRepeatUntilNoConflict/no_retries_needed
=== RUN   TestRepeatUntilNoConflict/max_retries_exceeded
=== PAUSE TestRepeatUntilNoConflict/max_retries_exceeded
=== RUN   TestRepeatUntilNoConflict/conflict_resolved
=== PAUSE TestRepeatUntilNoConflict/conflict_resolved
=== CONT  TestRepeatUntilNoConflict/no_retries_needed
=== CONT  TestRepeatUntilNoConflict/max_retries_exceeded
=== CONT  TestRepeatUntilNoConflict/conflict_resolved
--- PASS: TestRepeatUntilNoConflict (0.00s)
    --- PASS: TestRepeatUntilNoConflict/no_retries_needed (0.00s)
    --- PASS: TestRepeatUntilNoConflict/conflict_resolved (0.71s)
    --- PASS: TestRepeatUntilNoConflict/max_retries_exceeded (1.76s)
=== RUN   TestAccCustomRole_Create
--- PASS: TestAccCustomRole_Create (0.72s)
=== RUN   TestAccCustomRole_Update
--- PASS: TestAccCustomRole_Update (1.40s)
=== RUN   TestAccEnvironment_Create
--- PASS: TestAccEnvironment_Create (1.89s)
=== RUN   TestAccEnvironment_Update
--- PASS: TestAccEnvironment_Update (3.03s)
=== RUN   TestAccFeatureFlagEnvironment_Basic
--- PASS: TestAccFeatureFlagEnvironment_Basic (2.90s)
=== RUN   TestAccFeatureFlagEnvironment_Update
--- PASS: TestAccFeatureFlagEnvironment_Update (6.05s)
=== RUN   TestAccFeatureFlagEnvironment_Prereq
--- PASS: TestAccFeatureFlagEnvironment_Prereq (3.20s)
=== RUN   TestAccFeatureFlag_Basic
--- PASS: TestAccFeatureFlag_Basic (1.94s)
=== RUN   TestAccFeatureFlag_Update
--- PASS: TestAccFeatureFlag_Update (3.07s)
=== RUN   TestAccFeatureFlag_Number
--- PASS: TestAccFeatureFlag_Number (2.00s)
=== RUN   TestAccFeatureFlag_JSON
--- PASS: TestAccFeatureFlag_JSON (2.07s)
=== RUN   TestAccFeatureFlag_WithMaintainer
--- PASS: TestAccFeatureFlag_WithMaintainer (2.22s)
=== RUN   TestAccFeatureFlag_CreateMultivariate
--- PASS: TestAccFeatureFlag_CreateMultivariate (1.96s)
=== RUN   TestAccFeatureFlag_UpdateMultivariate
--- PASS: TestAccFeatureFlag_UpdateMultivariate (4.07s)
=== RUN   TestAccProject_Create
--- PASS: TestAccProject_Create (1.35s)
=== RUN   TestAccProject_Update
--- PASS: TestAccProject_Update (1.73s)
=== RUN   TestAccSegment_Create
--- PASS: TestAccSegment_Create (2.08s)
=== RUN   TestAccSegment_Update
--- PASS: TestAccSegment_Update (3.38s)
=== RUN   TestAccTeamMember_Create
--- PASS: TestAccTeamMember_Create (0.82s)
=== RUN   TestAccTeamMember_Update
--- PASS: TestAccTeamMember_Update (1.34s)
=== RUN   TestAccWebhook_Create
--- PASS: TestAccWebhook_Create (0.84s)
=== RUN   TestAccWebhook_Update
--- PASS: TestAccWebhook_Update (1.39s)
=== RUN   TestVariationsFromResourceData
=== RUN   TestVariationsFromResourceData/string_variations
=== RUN   TestVariationsFromResourceData/boolean_variations
=== RUN   TestVariationsFromResourceData/number_variations
=== RUN   TestVariationsFromResourceData/json_variations
--- PASS: TestVariationsFromResourceData (0.00s)
    --- PASS: TestVariationsFromResourceData/string_variations (0.00s)
    --- PASS: TestVariationsFromResourceData/boolean_variations (0.00s)
    --- PASS: TestVariationsFromResourceData/number_variations (0.00s)
    --- PASS: TestVariationsFromResourceData/json_variations (0.00s)
=== CONT  TestAccDataSourceTeamMember_noMatchReturnsError
--- PASS: TestAccDataSourceTeamMember_noMatchReturnsError (0.08s)
PASS
ok  	github.com/terraform-providers/terraform-provider-launchdarkly/launchdarkly	52.124s
```