### PR TITLE
Change module path to include full source path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module terraform-provider-launchdarkly
+module github.com/terraform-providers/terraform-provider-launchdarkly
 
 require (
 	github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6


### PR DESCRIPTION
As per other Terraform providers, the module path should include `github.com/terraform-providers` as a prefix.